### PR TITLE
Improve `transpose`, `adjoint` of vector `StridedView`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StridedViews"
 uuid = "4db3bf67-4bd7-4b4e-b153-31dc3fb37143"
 authors = ["Lukas Devos <lukas.devos@ugent.be>", "Jutho Haegeman <jutho.haegeman@ugent.be>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/Project.toml
+++ b/Project.toml
@@ -15,8 +15,12 @@ CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 StridedViewsCUDAExt = "CUDA"
 
 [compat]
+Aqua = "0.8"
 CUDA = "4,5"
+LinearAlgebra = "1.6"
 PackageExtensionCompat = "1"
+Random = "1.6"
+Test = "1.6"
 julia = "1.6"
 
 [extras]

--- a/src/stridedview.jl
+++ b/src/stridedview.jl
@@ -112,15 +112,15 @@ Base.conj(a::StridedView) = StridedView(a.parent, a.size, a.strides, a.offset, _
     return StridedView(a.parent, newsize, newstrides, a.offset, a.op)
 end
 
-Base.permutedims(a::StridedView{<:Any,1}) = sreshape(a, (1, length(a)))
-
-LinearAlgebra.transpose(a::StridedView{<:Number}) = permutedims(a)
-LinearAlgebra.adjoint(a::StridedView{<:Number}) = permutedims(conj(a))
-function LinearAlgebra.adjoint(a::StridedView) # act recursively, like Base
-    return permutedims(StridedView(a.parent, a.size, a.strides, a.offset, _adjoint(a.op)))
+LinearAlgebra.transpose(a::StridedView{<:Number,2}) = permutedims(a, (2, 1))
+LinearAlgebra.adjoint(a::StridedView{<:Number,2}) = permutedims(conj(a), (2, 1))
+function LinearAlgebra.adjoint(a::StridedView{<:Any,2}) # act recursively, like Base
+    return permutedims(StridedView(a.parent, a.size, a.strides, a.offset, _adjoint(a.op)),
+                       (2, 1))
 end
-function LinearAlgebra.transpose(a::StridedView) # act recursively, like Base
-    return permutedims(StridedView(a.parent, a.size, a.strides, a.offset, _transpose(a.op)))
+function LinearAlgebra.transpose(a::StridedView{<:Any,2}) # act recursively, like Base
+    return permutedims(StridedView(a.parent, a.size, a.strides, a.offset, _transpose(a.op)),
+                       (2, 1))
 end
 
 Base.map(::FC, a::StridedView{<:Real}) = a
@@ -170,6 +170,13 @@ sreshape(a, args::Vararg{Int}) = sreshape(a, args)
 end
 
 sreshape(a::AbstractArray, newsize::Dims) = sreshape(StridedView(a), newsize)
+
+function sreshape(a::LinearAlgebra.AdjointAbsVec, newsize::Dims)
+    return sreshape(conj(StridedView(adjoint(a))), newsize)
+end
+function sreshape(a::LinearAlgebra.TransposeAbsVec, newsize::Dims)
+    return sreshape(StridedView(transpose(a)), newsize)
+end
 
 # Other methods: `similar`, `copy`
 #----------------------------------

--- a/src/stridedview.jl
+++ b/src/stridedview.jl
@@ -112,15 +112,16 @@ Base.conj(a::StridedView) = StridedView(a.parent, a.size, a.strides, a.offset, _
     return StridedView(a.parent, newsize, newstrides, a.offset, a.op)
 end
 
-LinearAlgebra.transpose(a::StridedView{<:Number,2}) = permutedims(a, (2, 1))
-LinearAlgebra.adjoint(a::StridedView{<:Number,2}) = permutedims(conj(a), (2, 1))
-function LinearAlgebra.adjoint(a::StridedView{<:Any,2}) # act recursively, like Base
-    return permutedims(StridedView(a.parent, a.size, a.strides, a.offset, _adjoint(a.op)),
-                       (2, 1))
+Base.permutedims(a::StridedView{<:Any,1}) = sreshape(a, (1, length(a)))
+Base.permutedims(a::StridedView{<:Any,2}) = permutedims(a, (2, 1))
+
+LinearAlgebra.transpose(a::StridedView{<:Number}) = permutedims(a)
+LinearAlgebra.adjoint(a::StridedView{<:Number}) = permutedims(conj(a))
+function LinearAlgebra.adjoint(a::StridedView) # act recursively, like Base
+    return permutedims(StridedView(a.parent, a.size, a.strides, a.offset, _adjoint(a.op)))
 end
-function LinearAlgebra.transpose(a::StridedView{<:Any,2}) # act recursively, like Base
-    return permutedims(StridedView(a.parent, a.size, a.strides, a.offset, _transpose(a.op)),
-                       (2, 1))
+function LinearAlgebra.transpose(a::StridedView) # act recursively, like Base
+    return permutedims(StridedView(a.parent, a.size, a.strides, a.offset, _transpose(a.op)))
 end
 
 Base.map(::FC, a::StridedView{<:Real}) = a

--- a/src/stridedview.jl
+++ b/src/stridedview.jl
@@ -113,7 +113,6 @@ Base.conj(a::StridedView) = StridedView(a.parent, a.size, a.strides, a.offset, _
 end
 
 Base.permutedims(a::StridedView{<:Any,1}) = sreshape(a, (1, length(a)))
-Base.permutedims(a::StridedView{<:Any,2}) = permutedims(a, (2, 1))
 
 LinearAlgebra.transpose(a::StridedView{<:Number}) = permutedims(a)
 LinearAlgebra.adjoint(a::StridedView{<:Number}) = permutedims(conj(a))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,14 +114,9 @@ end
 @testset "transpose and adjoint with vector StridedView" begin
     @testset for T in (Float32, Float64, Complex{Float32}, Complex{Float64})
         A = randn(T, (60,))
-        B = StridedView(A)
 
-        @test isa(permutedims(B), StridedView)
-        @test permutedims(B) == permutedims(A)
-        @test isa(transpose(B), StridedView)
-        @test transpose(B) == transpose(A)
-        @test isa(adjoint(B), StridedView)
-        @test adjoint(B) == adjoint(A)
+        @test sreshape(transpose(A), (1, length(A))) == transpose(A)
+        @test sreshape(adjoint(A), (1, length(A))) == adjoint(A)
     end
 end
 
@@ -220,5 +215,4 @@ end
 end
 
 using Aqua
-Aqua.test_all(StridedViews;
-              project_toml_formatting=(VERSION >= v"1.9"))
+Aqua.test_all(StridedViews)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -111,6 +111,18 @@ Random.seed!(1234)
     end
 end
 
+@testset "transpose and adjoint with vector StridedView" begin
+    @testset for T in (Float32, Float64, Complex{Float32}, Complex{Float64})
+        A = randn(T, (60,))
+        B = StridedView(A)
+        @test isa(B, StridedView)
+
+        @test permutedims(B) == permutedims(A)
+        @test transpose(B) == transpose(A)
+        @test adjoint(B) == adjoint(A)
+    end
+end
+
 @testset "elementwise conj, transpose and adjoint" begin
     @testset for T in (Float32, Float64, Complex{Float32}, Complex{Float64})
         A = [rand(T) for i in 1:5, b in 1:4, c in 1:3, d in 1:2]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,10 +115,12 @@ end
     @testset for T in (Float32, Float64, Complex{Float32}, Complex{Float64})
         A = randn(T, (60,))
         B = StridedView(A)
-        @test isa(B, StridedView)
 
+        @test isa(permutedims(B), StridedView)
         @test permutedims(B) == permutedims(A)
+        @test isa(transpose(B), StridedView)
         @test transpose(B) == transpose(A)
+        @test isa(adjoint(B), StridedView)
         @test adjoint(B) == adjoint(A)
     end
 end


### PR DESCRIPTION
Hi @Jutho, this makes it so that `transpose` and `adjoint` of vector `StridedView` remains a `StridedView`.

I did this by generalizing `transpose` and `adjoint` to support both matrix and vector `StridedView` by calling `permutedims(::StridedView)`, and then making sure that works for vector `StridedView` by calling `sreshape` (so this PR also fixes `permutedims(::StridedView)` for vector `StridedView` as well). Open to other approaches.