### PR TITLE
Add `isstrided` trait

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StridedViews"
 uuid = "4db3bf67-4bd7-4b4e-b153-31dc3fb37143"
 authors = ["Lukas Devos <lukas.devos@ugent.be>", "Jutho Haegeman <jutho.haegeman@ugent.be>"]
-version = "0.2.2"
+version = "0.3"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/StridedViews.jl
+++ b/src/StridedViews.jl
@@ -5,7 +5,7 @@ using Base: @propagate_inbounds, RangeIndex, Dims
 const SliceIndex = Union{RangeIndex,Colon}
 
 using LinearAlgebra
-export StridedView, sreshape, sview
+export StridedView, sreshape, sview, isstrided
 
 include("auxiliary.jl")
 include("stridedview.jl")

--- a/src/stridedview.jl
+++ b/src/stridedview.jl
@@ -52,6 +52,25 @@ function StridedView(a::Base.PermutedDimsArray{T,N,P}) where {T,N,P}
     return permutedims(StridedView(a.parent), P)
 end
 
+# trait
+isstrided(a::DenseArray) = true
+isstrided(a::StridedView) = true
+isstrided(a::Adjoint) = isstrided(a')
+isstrided(a::Transpose) = isstrided(transpose(a))
+function isstrided(a::Base.SubArray)
+    return isstrided(a.parent) && all(Base.Fix2(isa, SliceIndex), a.indices)
+end
+function isstrided(a::Base.ReshapedArray)
+    isstrided(a.parent) || return false
+    newsize = a.dims
+    oldsize = size(a.parent)
+    any(isequal(0), newsize) && return true
+    newstrides = _computereshapestrides(newsize,
+                                        _simplifydims(oldsize, strides(a.parent))...)
+    return !isnothing(newstrides)
+end
+isstrided(a::Base.PermutedDimsArray) = isstrided(a.parent)
+
 # Elementary properties
 #-----------------------
 Base.size(a::StridedView) = a.size
@@ -156,6 +175,14 @@ end
 
 # Creating or transforming StridedView by reshaping
 #---------------------------------------------------
+# An error struct for non-strided reshapes
+struct ReshapeException <: Exception
+end
+function Base.show(io::IO, e::ReshapeException)
+    msg = "Cannot produce a reshaped StridedView without allocating, try sreshape(copy(array), newsize) or fall back to reshape(array, newsize)"
+    return print(io, msg)
+end
+
 # we cannot use Base.reshape, as this also accepts indices that might not preserve
 # stridedness
 sreshape(a, args::Vararg{Int}) = sreshape(a, args)
@@ -166,6 +193,7 @@ sreshape(a, args::Vararg{Int}) = sreshape(a, args)
     else
         newstrides = _computereshapestrides(newsize, _simplifydims(size(a), strides(a))...)
     end
+    isnothing(newstrides) && throw(ReshapeException())
     return StridedView(a.parent, newsize, newstrides, a.offset, a.op)
 end
 

--- a/src/stridedview.jl
+++ b/src/stridedview.jl
@@ -70,6 +70,7 @@ function isstrided(a::Base.ReshapedArray)
     return !isnothing(newstrides)
 end
 isstrided(a::Base.PermutedDimsArray) = isstrided(a.parent)
+isstrided(a::AbstractArray) = false
 
 # Elementary properties
 #-----------------------

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,6 +117,8 @@ Random.seed!(1234)
               StridedView(reshape(A8, (1, 1, 1))) == sreshape(A8, (1, 1, 1))
         @test reshape(B8, ()) == reshape(A8, ())
     end
+
+    @test !isstrided(Diagonal([0.5, 1.0, 1.5]))
 end
 
 @testset "transpose and adjoint with vector StridedView" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,8 @@ Random.seed!(1234)
         A1 = randn(T1, (60, 60))
         B1 = StridedView(A1)
         C1 = StridedView(B1)
+        @test isstrided(A1)
+        @test isstrided(B1)
         @test C1 === B1
         @test parent(B1) === A1
         @test Base.elsize(B1) == Base.elsize(A1)
@@ -25,6 +27,7 @@ Random.seed!(1234)
         end
 
         A2 = view(A1, 1:36, 1:20)
+        @test isstrided(A2)
         B2 = StridedView(A2)
         for op1 in (identity, conj, transpose, adjoint)
             if op1 == transpose || op1 == adjoint
@@ -38,6 +41,7 @@ Random.seed!(1234)
         end
 
         A3 = reshape(A1, 360, 10)
+        @test isstrided(A3)
         B3 = StridedView(A3)
         @test size(A3) == size(B3)
         @test strides(A3) == strides(B3)
@@ -56,6 +60,7 @@ Random.seed!(1234)
         end
 
         A4 = reshape(view(A1, 1:36, 1:20), (6, 6, 5, 4))
+        @test isstrided(A4)
         B4 = StridedView(A4)
         B4[2, 2, 2, 2] = 3
         @test A4[2, 2, 2, 2] == 3
@@ -67,6 +72,7 @@ Random.seed!(1234)
         end
 
         A5 = PermutedDimsArray(reshape(view(A1, 1:36, 1:20), (6, 6, 5, 4)), (3, 1, 2, 4))
+        @test isstrided(A5)
         B5 = StridedView(A5)
         for op1 in (identity, conj)
             @test op1(A5) == op1(B5)
@@ -76,6 +82,7 @@ Random.seed!(1234)
         end
 
         A6 = reshape(view(A1, 1:36, 1:20), (6, 120))
+        @test !isstrided(A6)
         @test_throws StridedViews.ReshapeException StridedView(A6)
         try
             StridedView(A6)
@@ -87,6 +94,7 @@ Random.seed!(1234)
 
         # Array with Array elements
         A7 = [randn(T1, (5, 5)) for i in 1:5, j in 1:5]
+        @test isstrided(A7)
         B7 = StridedView(A7)
         for op1 in (identity, conj, transpose, adjoint)
             @test op1(A7) == op1(B7) == StridedView(op1(A7))
@@ -117,6 +125,8 @@ end
 
         @test sreshape(transpose(A), (1, length(A))) == transpose(A)
         @test sreshape(adjoint(A), (1, length(A))) == adjoint(A)
+        @test isstrided(transpose(A))
+        @test isstrided(adjoint(A))
     end
 end
 


### PR DESCRIPTION
This can be used to check whether an `AbstractArray` instance can be converted to a `StridedView`. 