### PR TITLE
Normalize parent array type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StridedViews"
 uuid = "4db3bf67-4bd7-4b4e-b153-31dc3fb37143"
 authors = ["Lukas Devos <lukas.devos@ugent.be>", "Jutho Haegeman <jutho.haegeman@ugent.be>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StridedViews"
 uuid = "4db3bf67-4bd7-4b4e-b153-31dc3fb37143"
 authors = ["Lukas Devos <lukas.devos@ugent.be>", "Jutho Haegeman <jutho.haegeman@ugent.be>"]
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/README.md
+++ b/README.md
@@ -50,3 +50,10 @@ subsequent dimensions `i` and `i+1` can only be joined if `stride(A,i+1) ==
 size(A,i)*stride(A,i)`. Instead of overloading `reshape`, Strided.jl provides a separate
 function `sreshape` which returns a `StridedView` over the same parent data, or throws a
 runtime error if this is impossible.
+
+### News
+
+Since StridedViews v0.4.0, the `StridedView` type attempts to generate less specializations
+by normalizing the parent array type. In particular, for `DenseArray` parents we attempt to
+reshape the parent array to a vector, and for `Memory`-based arrays (Julia v1.11+) we unpack
+the `Memory` object directly. This should improve compile times.

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -45,6 +45,10 @@ function _normalizestrides(size::Dims{N}, strides::Dims{N}) where {N}
     return strides
 end
 
+# 'Normalize' the layout of a DenseArray, in order to reduce the number of required
+# specializations in functions.
+@inline _normalizeparent(A::DenseArray) = reshape(A, length(A))
+
 # Auxiliary methods for `sview`
 #------------------------------
 # Compute the new dimensions of a strided view given the original size and the view slicing

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -47,6 +47,9 @@ end
 
 # 'Normalize' the layout of a DenseArray, in order to reduce the number of required
 # specializations in functions.
+@static if isdefined(Core, :Memory)
+    @inline _normalizeparent(A::Array) = A.ref.mem
+end
 @inline _normalizeparent(A::DenseArray) = reshape(A, length(A))
 
 # Auxiliary methods for `sview`

--- a/src/stridedview.jl
+++ b/src/stridedview.jl
@@ -34,13 +34,15 @@ end
 
 # Constructors
 #--------------
-function StridedView(parent::A,
+function StridedView(parent::DenseArray,
                      size::NTuple{N,Int}=size(parent),
                      strides::NTuple{N,Int}=strides(parent),
                      offset::Int=0,
-                     op::F=identity) where {A<:DenseArray,N,F}
+                     op::F=identity) where {N,F}
     T = Base.promote_op(op, eltype(parent))
-    return StridedView{T,N,A,F}(parent, size, _normalizestrides(size, strides), offset, op)
+    parent′ = _normalizeparent(parent)
+    strides′ = _normalizestrides(size, strides)
+    return StridedView{T,N,typeof(parent′),F}(parent′, size, strides′, offset, op)
 end
 
 StridedView(a::StridedView) = a

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ Random.seed!(1234)
         @test isstrided(A1)
         @test isstrided(B1)
         @test C1 === B1
-        @test parent(B1) === A1
+        @test parent(B1) == reshape(A1, :)
         @test Base.elsize(B1) == Base.elsize(A1)
         for op1 in (identity, conj, transpose, adjoint)
             if op1 == transpose || op1 == adjoint


### PR DESCRIPTION
This PR brings back a change that was present in older versions of Strided.jl, by normalizing the parent type of `StridedView` to only include `Vector`.
This main reason is [this TensorOperations.jl PR](https://github.com/Jutho/TensorOperations.jl/pull/203) which introduces some precompilation efforts, reporting a rather large amount of specializations from `Strided`.
While there is definitely room for adding precompilation in this package as well, to further decrease the burden on TensorOperations itself, this seems like a rather simple change that has a huge impact on the precompilation times: my machine reports ~140 seconds before, but ~40 seconds after.
Alternatively, we could also consider just normalizing the types in `TensorOperations` itself, but this change seems reasonable to me.

I'm not sure if this constitutes a breaking change though, given that fields are typically considered private I would say it isn't?