### PR TITLE
`PtrArrays` extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StridedViews"
 uuid = "4db3bf67-4bd7-4b4e-b153-31dc3fb37143"
 authors = ["Lukas Devos <lukas.devos@ugent.be>", "Jutho Haegeman <jutho.haegeman@ugent.be>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/Project.toml
+++ b/Project.toml
@@ -10,23 +10,27 @@ PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+PtrArrays = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
 
 [extensions]
 StridedViewsCUDAExt = "CUDA"
+StridedViewsPtrArraysExt = "PtrArrays"
 
 [compat]
 Aqua = "0.8"
 CUDA = "4,5"
 LinearAlgebra = "1.6"
 PackageExtensionCompat = "1"
+PtrArrays = "1.2.0"
 Random = "1.6"
 Test = "1.6"
 julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+PtrArrays = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "Aqua"]
+test = ["Test", "Random", "Aqua", "PtrArrays"]

--- a/ext/StridedViewsPtrArraysExt.jl
+++ b/ext/StridedViewsPtrArraysExt.jl
@@ -1,0 +1,8 @@
+module StridedViewsPtrArraysExt
+
+using StridedViews
+using PtrArrays
+
+StridedViews._normalizeparent(A::PtrArray) = PtrArray(A.ptr, length(A))
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -250,5 +250,16 @@ end
     end
 end
 
+using PtrArrays
+@testset "PtrArrays with StridedView" begin
+    @testset for T in (Float64, ComplexF64)
+        A = randn!(malloc(T, 10, 10, 10, 10))
+        @test isstrided(A)
+        B = StridedView(A)
+        @test B isa StridedView
+        free(A)
+    end
+end
+
 using Aqua
 Aqua.test_all(StridedViews)


### PR DESCRIPTION
The new version seems to have broken the compatibility with `PtrArrays.jl`, since `reshape(::PtrArray)` produces a lazy reshaped array, which then no longer is a subtype of `DenseArray`.

Here I simply circumvent that issue by correctly reshaping the `PtrArray` manually, but probably it is also fair to be slightly more conservative and only define the `_normalizeparent` function for `Array` -- making this functionality more opt-in instead of opt-out.
@Jutho if you agree, I'll address that in a separate PR.