### PR TITLE
Dedicated `Adapt` extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
 
 [weakdeps]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDACore = "bd0ed864-bdfe-4181-a5ed-ce625a5fdea2"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
@@ -19,9 +20,11 @@ StridedViewsAMDGPUExt = "AMDGPU"
 StridedViewsCUDACoreExt = "CUDACore"
 StridedViewsJLArraysExt = "JLArrays"
 StridedViewsPtrArraysExt = "PtrArrays"
+StridedViewsAdaptExt = "Adapt"
 
 [compat]
 AMDGPU = "2"
+Adapt = "4"
 Aqua = "0.8"
 CUDACore = "6"
 JET = "0.9, 0.10, 0.11"
@@ -36,6 +39,7 @@ julia = "1.10"
 
 [extras]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CUDACore = "bd0ed864-bdfe-4181-a5ed-ce625a5fdea2"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
@@ -46,4 +50,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "Aqua", "JET", "PtrArrays", "CUDACore", "AMDGPU", "JLArrays", "Metal"]
+test = ["Test", "Random", "Aqua", "JET", "PtrArrays", "CUDACore", "AMDGPU", "JLArrays", "Metal", "Adapt"]

--- a/ext/StridedViewsAMDGPUExt.jl
+++ b/ext/StridedViewsAMDGPUExt.jl
@@ -6,13 +6,6 @@ using AMDGPU: Adapt
 
 const ROCStridedView{T, N, A <: ROCArray{T}} = StridedView{T, N, A}
 
-function Adapt.adapt_structure(to, A::ROCStridedView)
-    return StridedView(
-        Adapt.adapt_structure(to, parent(A)),
-        A.size, A.strides, A.offset, A.op
-    )
-end
-
 function Base.pointer(x::ROCStridedView{T}) where {T}
     return Base.unsafe_convert(Ptr{T}, pointer(x.parent, x.offset + 1))
 end
@@ -21,7 +14,7 @@ function Base.unsafe_convert(::Type{Ptr{T}}, a::ROCStridedView{T}) where {T}
 end
 
 function Base.print_array(io::IO, X::ROCStridedView)
-    return Base.print_array(io, Adapt.adapt_structure(Array, X))
+    return Base.print_array(io, Adapt.adapt(Array, X))
 end
 
 end # module

--- a/ext/StridedViewsAdaptExt.jl
+++ b/ext/StridedViewsAdaptExt.jl
@@ -1,0 +1,9 @@
+module StridedViewsAdaptExt
+
+using Adapt
+using StridedViews
+
+Adapt.adapt_structure(to, x::StridedView) =
+    StridedView(adapt(to, parent(x)), size(x), strides(x), x.offset, x.op)
+
+end

--- a/ext/StridedViewsCUDACoreExt.jl
+++ b/ext/StridedViewsCUDACoreExt.jl
@@ -6,13 +6,6 @@ using CUDACore: Adapt, CuPtr
 
 const CuStridedView{T, N, A <: CuArray{T}} = StridedView{T, N, A}
 
-function Adapt.adapt_structure(to, A::CuStridedView)
-    return StridedView(
-        Adapt.adapt_structure(to, parent(A)),
-        A.size, A.strides, A.offset, A.op
-    )
-end
-
 function Base.pointer(x::CuStridedView{T}) where {T}
     return Base.unsafe_convert(CuPtr{T}, pointer(x.parent, x.offset + 1))
 end
@@ -21,7 +14,7 @@ function Base.unsafe_convert(::Type{CuPtr{T}}, a::CuStridedView{T}) where {T}
 end
 
 function Base.print_array(io::IO, X::CuStridedView)
-    return Base.print_array(io, Adapt.adapt_structure(Array, X))
+    return Base.print_array(io, Adapt.adapt(Array, X))
 end
 
 end # module

--- a/ext/StridedViewsJLArraysExt.jl
+++ b/ext/StridedViewsJLArraysExt.jl
@@ -6,13 +6,6 @@ using JLArrays: Adapt
 
 const JLArrayStridedView{T, N, A <: JLArray{T}} = StridedView{T, N, A}
 
-function Adapt.adapt_structure(to, A::JLArrayStridedView)
-    return StridedView(
-        Adapt.adapt_structure(to, parent(A)),
-        A.size, A.strides, A.offset, A.op
-    )
-end
-
 function Base.pointer(x::JLArrayStridedView{T}) where {T}
     return Base.unsafe_convert(Ptr{T}, pointer(x.parent, x.offset + 1))
 end
@@ -21,7 +14,7 @@ function Base.unsafe_convert(::Type{Ptr{T}}, a::JLArrayStridedView{T}) where {T}
 end
 
 function Base.print_array(io::IO, X::JLArrayStridedView)
-    return Base.print_array(io, Adapt.adapt_structure(Array, X))
+    return Base.print_array(io, Adapt.adapt(Array, X))
 end
 
 end # module

--- a/ext/StridedViewsMetalExt.jl
+++ b/ext/StridedViewsMetalExt.jl
@@ -6,13 +6,6 @@ using Metal: Adapt, MtlPtr
 
 const MtlStridedView{T, N, A <: MtlArray{T}} = StridedView{T, N, A}
 
-function Adapt.adapt_structure(to, A::MtlStridedView)
-    return StridedView(
-        Adapt.adapt_structure(to, parent(A)),
-        A.size, A.strides, A.offset, A.op
-    )
-end
-
 function Base.pointer(x::MtlStridedView{T}) where {T}
     return Base.unsafe_convert(MtlPtr{T}, pointer(x.parent, x.offset + 1))
 end
@@ -21,7 +14,7 @@ function Base.unsafe_convert(::Type{MtlPtr{T}}, a::MtlStridedView{T}) where {T}
 end
 
 function Base.print_array(io::IO, X::MtlStridedView)
-    return Base.print_array(io, Adapt.adapt_structure(Array, X))
+    return Base.print_array(io, Adapt.adapt(Array, X))
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using LinearAlgebra
 using Random
 using StridedViews
+using Adapt
 using JLArrays
 
 Random.seed!(1234)
@@ -301,8 +302,9 @@ if !is_buildkite
             JLArrays.@allowscalar begin
                 @test B == A
             end
-            Bvec = JLArrays.Adapt.adapt(Vector{T}, B)
+            Bvec = adapt(Vector{T}, B)
             @test Bvec == StridedView(Araw)
+            @test parent(adapt(JLArray, Bvec)) isa JLArray
         end
     end
 


### PR DESCRIPTION
This consolidates the `Adapt` implementation into its own extension, removing some mild "package piracy" in the extensions and supporting any parent type that has an `adapt` implementation.