### PR TITLE
Cut compile time: de-inline setup helpers + add a small precompile workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "StridedViews"
 uuid = "4db3bf67-4bd7-4b4e-b153-31dc3fb37143"
 authors = ["Lukas Devos <lukas.devos@ugent.be>", "Jutho Haegeman <jutho.haegeman@ugent.be>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [weakdeps]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
@@ -28,6 +29,7 @@ CUDACore = "6"
 JLArrays = "0.3.1"
 LinearAlgebra = "1"
 Metal = "1"
+PrecompileTools = "1"
 PtrArrays = "1.2.0"
 julia = "1.10"
 

--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ CUDACore = "6"
 JLArrays = "0.3.1"
 LinearAlgebra = "1"
 Metal = "1"
-PrecompileTools = "1"
+PrecompileTools = "1.1"
 PtrArrays = "1.2.0"
 julia = "1.10"
 

--- a/src/StridedViews.jl
+++ b/src/StridedViews.jl
@@ -9,5 +9,6 @@ export StridedView, sreshape, sview, isstrided
 
 include("auxiliary.jl")
 include("stridedview.jl")
+include("precompile.jl")
 
 end

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -58,7 +58,7 @@ end
 #------------------------------
 # Compute the new dimensions of a strided view given the original size and the view slicing
 # indices
-function _computeviewsize(oldsize::NTuple{N, Int}, I::NTuple{N, SliceIndex}) where {N}
+@inline function _computeviewsize(oldsize::NTuple{N, Int}, I::NTuple{N, SliceIndex}) where {N}
     if isa(I[1], Int)
         return _computeviewsize(tail(oldsize), tail(I))
     elseif isa(I[1], Colon)
@@ -71,7 +71,7 @@ _computeviewsize(::Tuple{}, ::Tuple{}) = ()
 
 # Compute the new strides of a (strided) view given the original strides and the view
 # slicing indices
-function _computeviewstrides(
+@inline function _computeviewstrides(
         oldstrides::NTuple{N, Int},
         I::NTuple{N, SliceIndex}
     ) where {N}
@@ -90,7 +90,7 @@ _computeviewstrides(::Tuple{}, ::Tuple{}) = ()
 
 # Compute the additional offset of a (strided) view given the original strides and the view
 # slicing indices
-function _computeviewoffset(
+@inline function _computeviewoffset(
         strides::NTuple{N, Int},
         I::NTuple{N, SliceIndex}
     ) where {N}

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -58,7 +58,7 @@ end
 #------------------------------
 # Compute the new dimensions of a strided view given the original size and the view slicing
 # indices
-@inline function _computeviewsize(oldsize::NTuple{N, Int}, I::NTuple{N, SliceIndex}) where {N}
+function _computeviewsize(oldsize::NTuple{N, Int}, I::NTuple{N, SliceIndex}) where {N}
     if isa(I[1], Int)
         return _computeviewsize(tail(oldsize), tail(I))
     elseif isa(I[1], Colon)
@@ -71,7 +71,7 @@ _computeviewsize(::Tuple{}, ::Tuple{}) = ()
 
 # Compute the new strides of a (strided) view given the original strides and the view
 # slicing indices
-@inline function _computeviewstrides(
+function _computeviewstrides(
         oldstrides::NTuple{N, Int},
         I::NTuple{N, SliceIndex}
     ) where {N}
@@ -90,7 +90,7 @@ _computeviewstrides(::Tuple{}, ::Tuple{}) = ()
 
 # Compute the additional offset of a (strided) view given the original strides and the view
 # slicing indices
-@inline function _computeviewoffset(
+function _computeviewoffset(
         strides::NTuple{N, Int},
         I::NTuple{N, SliceIndex}
     ) where {N}

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -4,29 +4,29 @@
 # range of dimensionalities and the op-wrappers a `StridedView` can carry. These are the
 # specializations that downstream packages (e.g. TensorOperations / Strided) hit on their
 # first call, so warming them here removes that first-call latency.
-#
-# The workload is deliberately kept small (BLAS floats, ndims 1:4, identity/conj plus the
-# 2D transpose/adjoint cases) so that it adds only a bounded amount to StridedViews' own
-# precompile time.
 using PrecompileTools: @setup_workload, @compile_workload
 
 @setup_workload begin
     @compile_workload begin
         for T in (Float32, Float64, ComplexF32, ComplexF64)
             # construction + property queries + core ops for ndims 1:4
-            for N in 1:4
+            for N in 1:6
                 A = Array{T, N}(undef, ntuple(_ -> 2, N))
                 sv = StridedView(A)
                 size(sv)
                 strides(sv)
                 offset(sv)
-                conj(sv)
+                csv = conj(sv)
                 # permute through the identity permutation (exercises the per-N path)
                 permutedims(sv, ntuple(identity, N))
+                permutedims(csv, ntuple(identity, N))
                 # reshape to a flat vector and back (also exercises sview on the flat view)
                 flat = sreshape(sv, (length(sv),))
                 sview(flat, 1:length(sv))
                 getindex(sv, ntuple(_ -> 1, N)...)
+                flat = sreshape(csv, (length(sv),))
+                sview(flat, 1:length(csv))
+                getindex(csv, ntuple(_ -> 1, N)...)
             end
             # 2D matrix wrappers: transpose / adjoint
             M = Array{T, 2}(undef, 2, 2)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,42 @@
+# Precompilation workload
+# ------------------------
+# Cache the core `StridedView` specializations for the BLAS element types over a small
+# range of dimensionalities and the op-wrappers a `StridedView` can carry. These are the
+# specializations that downstream packages (e.g. TensorOperations / Strided) hit on their
+# first call, so warming them here removes that first-call latency.
+#
+# The workload is deliberately kept small (BLAS floats, ndims 1:4, identity/conj plus the
+# 2D transpose/adjoint cases) so that it adds only a bounded amount to StridedViews' own
+# precompile time.
+using PrecompileTools: @setup_workload, @compile_workload
+
+@setup_workload begin
+    @compile_workload begin
+        for T in (Float32, Float64, ComplexF32, ComplexF64)
+            # construction + property queries + core ops for ndims 1:4
+            for N in 1:4
+                A = Array{T, N}(undef, ntuple(_ -> 2, N))
+                sv = StridedView(A)
+                size(sv)
+                strides(sv)
+                offset(sv)
+                conj(sv)
+                # permute through the identity permutation (exercises the per-N path)
+                permutedims(sv, ntuple(identity, N))
+                # reshape to a flat vector and back (also exercises sview on the flat view)
+                flat = sreshape(sv, (length(sv),))
+                sview(flat, 1:length(sv))
+                getindex(sv, ntuple(_ -> 1, N)...)
+            end
+            # 2D matrix wrappers: transpose / adjoint
+            M = Array{T, 2}(undef, 2, 2)
+            svM = StridedView(M)
+            transpose(svM)
+            adjoint(svM)
+            # a representative 4D slice view (the SliceIndex `getindex` construction path)
+            A4 = Array{T, 4}(undef, 2, 2, 2, 2)
+            sv4 = StridedView(A4)
+            getindex(sv4, :, 1:2, 1, 1:2)
+        end
+    end
+end

--- a/src/stridedview.jl
+++ b/src/stridedview.jl
@@ -138,8 +138,11 @@ end
     return a
 end
 
-# Indexing with slice indices to create a new view
-@inline function Base.getindex(a::StridedView{T, N}, I::Vararg{SliceIndex, N}) where {T, N}
+# Indexing with slice indices to create a new view.
+# This builds a *new* view (a once-per-operation setup step, not a hot inner loop), so we
+# deliberately do not force-inline it: `@inline` here duplicated the per-N size/stride/offset
+# computation into every downstream caller instead of compiling it once per signature.
+function Base.getindex(a::StridedView{T, N}, I::Vararg{SliceIndex, N}) where {T, N}
     return StridedView{T}(
         a.parent,
         _computeviewsize(a.size, I),
@@ -179,7 +182,7 @@ function Base.conj(a::StridedView)
     return StridedView{T}(a.parent, a.size, a.strides, a.offset, newop)
 end
 
-@inline function Base.permutedims(a::StridedView{T, N}, p) where {T, N}
+function Base.permutedims(a::StridedView{T, N}, p) where {T, N}
     _isperm(N, p) || throw(ArgumentError("Invalid permutation of length $N: $p"))
     newsize = ntuple(n -> size(a, p[n]), Val(N))
     newstrides = ntuple(n -> stride(a, p[n]), Val(N))
@@ -228,10 +231,10 @@ sview(a::StridedView, I::SliceIndex) = getindex(sreshape(a, (length(a),)), I)
 Base.view(a::StridedView{<:Any, N}, I::Vararg{SliceIndex, N}) where {N} = getindex(a, I...)
 
 # `sview` can be used as a constructor when acting on `AbstractArray` objects
-@inline function sview(a::AbstractArray{<:Any, N}, I::Vararg{SliceIndex, N}) where {N}
+function sview(a::AbstractArray{<:Any, N}, I::Vararg{SliceIndex, N}) where {N}
     return getindex(StridedView(a), I...)
 end
-@inline function sview(a::AbstractArray, I::SliceIndex)
+function sview(a::AbstractArray, I::SliceIndex)
     return getindex(sreshape(StridedView(a), (length(a),)), I)
 end
 
@@ -251,7 +254,7 @@ end
 # we cannot use Base.reshape, as this also accepts indices that might not preserve
 # stridedness
 sreshape(a, args::Vararg{Int}) = sreshape(a, args)
-@inline function sreshape(a::StridedView{T}, newsize::Dims) where {T}
+function sreshape(a::StridedView{T}, newsize::Dims) where {T}
     if any(isequal(0), newsize)
         any(isequal(0), size(a)) || throw(DimensionMismatch())
         newstrides = one.(newsize)

--- a/src/stridedview.jl
+++ b/src/stridedview.jl
@@ -139,9 +139,6 @@ end
 end
 
 # Indexing with slice indices to create a new view.
-# This builds a *new* view (a once-per-operation setup step, not a hot inner loop), so we
-# deliberately do not force-inline it: `@inline` here duplicated the per-N size/stride/offset
-# computation into every downstream caller instead of compiling it once per signature.
 function Base.getindex(a::StridedView{T, N}, I::Vararg{SliceIndex, N}) where {T, N}
     return StridedView{T}(
         a.parent,
@@ -251,8 +248,7 @@ function Base.show(io::IO, e::ReshapeException)
     return print(io, msg)
 end
 
-# we cannot use Base.reshape, as this also accepts indices that might not preserve
-# stridedness
+# we cannot use Base.reshape, as this also accepts indices that might not preserve stridedness
 sreshape(a, args::Vararg{Int}) = sreshape(a, args)
 function sreshape(a::StridedView{T}, newsize::Dims) where {T}
     if any(isequal(0), newsize)

--- a/test/jet/Project.toml
+++ b/test/jet/Project.toml
@@ -4,8 +4,5 @@ name = "StridedViewsJETTest"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 StridedViews = "4db3bf67-4bd7-4b4e-b153-31dc3fb37143"
 
-[sources]
-StridedViews = {path = "../.."}
-
 [compat]
 JET = "0.9, 0.10, 0.11"

--- a/test/jet/jet.jl
+++ b/test/jet/jet.jl
@@ -2,6 +2,7 @@
     import Pkg
     try
         Pkg.activate(joinpath(@__DIR__); io = devnull)
+        Pkg.develop(Pkg.PackageSpec(path = joinpath(@__DIR__, "..", "..")); io = devnull)
         Pkg.instantiate(; io = devnull)
         @eval import JET
         JET.test_package(StridedViews; target_modules = (StridedViews,))


### PR DESCRIPTION
This PR removes some of the forced `@inline` annotations on `sreshape` and `permutedims`, which, combined with the `@inline` calls on the recursive `_compute*` for the strides and sizes functions meant that these methods have to be compiled in quite a lot of the TensorOperations kernels, for each different combination of `T,N,...`.
This PR just removes the annotation, allowing the compiler to decide when to inline, which seems to have quite a large impact on the actual compilation time in TensorOperations calls.

On top of that, since these functions are not inlined, it now makes sense to add a precompilation workload as well, in an attempt to remove some of the TTFX as well as precompile time burden in TensorOperations.

From what I can measure, it seems to reduce about 25% of the TTFX on a workload in TensorOperations where I exhaustively perform all binary contractions up to `N1,N2,N3 <= 3` (open,contracted,open legs).
On my machine, precompilation time is order ~2 seconds, so this hurts very little.

The runtime cost at the TensorOperations level is negligible, so I'd say to just merge and release this.

---

### Precompile-time comparison: TensorOperations suite, `main` vs this PR

Cold-precompiling the TensorOperations precompile workload (enabled, fixed grid
`precompile_contract_ndims=[3,2]`, `precompile_add_ndims=3`, `precompile_trace_ndims=[3,2]`,
eltypes `[Float64, ComplexF64]`), back-to-back on Julia 1.12.6:

| precompile of… | StridedViews `main` | StridedViews (this PR) | Δ |
|---|---:|---:|---:|
| **TensorOperations (the workload suite)** | **90.9 s** | **68.0 s** | **−22.9 s (−25%)** |
| Strided | 1.72 s | 1.90 s | +0.2 s (noise) |
| StridedViews itself | 0.59 s | 3.59 s | +3.0 s (this PR's `@compile_workload`) |
| **whole environment (cold)** | **93.3 s** | **75.4 s** | **−17.9 s (−19%)** |

The de-inlining stops TensorOperations' contraction specializations from re-inferring the
StridedView stride/permute helpers, so its precompile suite is ~25% cheaper. The added cost
lives in StridedViews' own precompile (+3.0 s, one-time per build, shared by all downstream),
for a net ~19% faster cold precompile of the whole environment.
